### PR TITLE
Add bio in profile section

### DIFF
--- a/_includes/profile.html
+++ b/_includes/profile.html
@@ -1,6 +1,9 @@
 <div class="profile">
+  <div>
+    <h2>{{ site.title }}</h2>
     <div class="profile-picture">
-        <img src="./assets/img/logo.jpg">
+      <img src="./assets/img/logo.jpg" />
     </div>
-    <h1>{{ site.title }}</h1>
+  </div>
+  <div class="profile__bio">{{ site.description }}</div>
 </div>

--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -3,7 +3,11 @@
     text-align: center;
     height: 320px;
     margin-bottom: 50px;
-    h1 {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+
+    h2 {
         font-size: 50px;
         font-weight: 700;
         color: white;
@@ -16,11 +20,14 @@
         margin-left: auto;
         margin-right: auto;
         display: block;        
-        padding: 20px;
     }
     
     .profile-picture {
         margin-bottom: 30px;
         height: 200px;
+    }
+
+    &__bio {
+        max-width: 50%;
     }
 }


### PR DESCRIPTION
Fix #5

The header section is changed to include bio as well, along with a photo and name.

Current:
![image](https://user-images.githubusercontent.com/56799401/127202288-32686e4f-97b1-439c-ba6c-f8c1c36c9101.png)

This is changed to:
![image](https://user-images.githubusercontent.com/56799401/127202585-2ee01f91-8abb-463c-baec-4e4dcd01663f.png)

